### PR TITLE
add inline style to a tags in listing component

### DIFF
--- a/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
+++ b/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
@@ -246,6 +246,10 @@ p {
   padding: 0 15px 0 0;
 }
 
+.listing h3 a {
+  display: inline;
+}
+
 .listing .map {
   position: absolute;
   top: 13px;


### PR DESCRIPTION
Addresses comment here:
https://github.com/emberjs/super-rentals/pull/24#discussion_r66380451

Making the title a link allows us to access the `show` sub-route, but we will need it to be inline as to not mess up the other styling