### PR TITLE
Make CSS selector more specific to ensure image is enlarged on click

### DIFF
--- a/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
+++ b/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
@@ -215,7 +215,7 @@ p {
   border-radius: 5px;
 }
 
-.listing .wide {
+.listing a.image.wide {
   max-width: 100%;
   position: relative;
   z-index: 999;


### PR DESCRIPTION
".listing .wide" is less specific than ".listing a.image" and is therefore
overridden. This means that the image does not expand to the full width in the
Ember tutorial demo. By making the first selector more specific the issue is
fixed.

closes #2