### PR TITLE
Fix link for Teaching Tomster

### DIFF
--- a/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
+++ b/blueprints/ember-cli-tutorial-style/files/vendor/ember-tutorial.css
@@ -326,7 +326,7 @@ p {
 }
 
 .tomster {
-    background: url(http://emberjs.com/images/tomsters/teaching.png);
+    background: url(http://emberjs.com/images/tomsters/teaching-reverse-79f66d70.png);
     background-size: contain;
     background-repeat: no-repeat;
     height: 200px;


### PR DESCRIPTION
My choice was between:
- http://emberjs.com/images/tomsters/teaching-reverse-79f66d70.png
- and http://www.emberjs.com/images/tomsters/teaching-c05e27c7.png
It's up to you.