### PR TITLE
Urgent Security Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "ember-source": "~2.18.0",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "clean-css": "^4.2.1"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"


### PR DESCRIPTION
- updated version of clean-css to 4.2.1. versions of clean css before 4.1.1 are susceptible to ReDoS attacks.